### PR TITLE
Build libtiledbvcf with Ubuntu 24 (GCC 13)

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -183,7 +183,7 @@ jobs:
       - name: Test
         run: R -e 'tinytest::test_package("tiledb")'
   libtiledbvcf:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     needs: libtiledb
     env:
       LD_LIBRARY_PATH: ${{ github.workspace }}/install-libtiledb/lib

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -202,6 +202,8 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes cmake
+          # Install htslib dependencies
+          sudo apt-get install -y automake autoconf libbz2-dev liblzma-dev
       - name: Configure libtiledbvcf
         run: |
           cmake -S libtiledbvcf -B build-libtiledbvcf \


### PR DESCRIPTION
Closes #28

Follow-up to #27 

When migrating the upstream CI for TileDB-VCF to ubuntu-24.04 (https://github.com/TileDB-Inc/TileDB-VCF/pull/788), I discovered why only libtiledbvcf was failing with Ubuntu 24 (GCC 13). It's because some requirements for building htslib from source were dropped between Ubuntu 22 and 24, and unfortunately the error messages are hidden in CMake log files. I was able to see the actual errors during the source build of bcftools (which also builds htslib from source) in the upstream CI.