### PR TITLE
Prefer binary PyPI pkgs to avoid spurious failures from source builds

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -109,6 +109,7 @@ jobs:
     env:
       LD_LIBRARY_PATH: ${{ github.workspace }}/install-libtiledb/lib
       PKG_CONFIG_PATH: ${{ github.workspace }}/install-libtiledb/lib/pkgconfig
+      PIP_PREFER_BINARY: 1
     steps:
       - name: Clone TileDB-Py
         uses: actions/checkout@v4
@@ -245,6 +246,7 @@ jobs:
     needs: [libtiledb, libtiledbvcf, tiledb-py]
     env:
       LD_LIBRARY_PATH: "${{ github.workspace }}/install-libtiledb/lib:${{ github.workspace }}/install-libtiledbvcf/lib"
+      PIP_PREFER_BINARY: 1
     steps:
       - name: Clone TileDB-VCF
         uses: actions/checkout@v4
@@ -371,6 +373,7 @@ jobs:
       TILEDB_PATH: ${{ github.workspace }}/install-libtiledb
       TILEDBSOMA_PATH: ${{ github.workspace }}/install-libtiledbsoma
       PKG_CONFIG_PATH: "${{ github.workspace }}/install-libtiledb/lib/pkgconfig:${{ github.workspace }}/install-libtiledbsoma/lib/pkgconfig"
+      PIP_PREFER_BINARY: 1
     steps:
       - name: Clone TileDB-SOMA
         uses: actions/checkout@v4
@@ -588,6 +591,7 @@ jobs:
     needs: [libtiledb, tiledb-py]
     env:
       LD_LIBRARY_PATH: "${{ github.workspace }}/install-libtiledb/lib"
+      PIP_PREFER_BINARY: 1
     steps:
       - name: Clone TileDB-Cloud-Py
         uses: actions/checkout@v4


### PR DESCRIPTION
To avoid spurious errors caused by installing from a source tarball when a new release does not yet have binaries available (which just happened last night when shapely was updated; #35), I have defined the env var [`PIP_PREFER_BINARY`](https://pip.pypa.io/en/stable/cli/pip_install/#cmdoption-prefer-binary) for all the Python builds. This should favor installing the previous release of a dependency that has a binary available.

Note that there is no guidance in the docs I found on what to set the env var to. From a [search of GitHub](https://github.com/search?utf8=%E2%9C%93&q=PIP_PREFER_BINARY&type=code&p=1), I observed `true` and `1`, and the latter appeared more popular, so I used it.

This already successfully ran on my [fork](https://github.com/jdblischak/centralized-tiledb-nightlies/actions/runs/13076250584). Unfortunately the shapely binaries are already available, so it's not possible to know if this will truly prevent the problem in the future. But at minimum it doesn't break anything.

