### PR TITLE
Run `make data` for tiledbsoma-py tests

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -435,6 +435,7 @@ jobs:
           python -c "import tiledbsoma; print(tiledbsoma.pytiledbsoma.version())"
           python -c "import tiledbsoma; print(f'tiledbsoma-py={tiledbsoma.__version__}')"
           # Obtain test data
+          make data
           cd test
           tar zxf soco.tgz
           cd ..


### PR DESCRIPTION
Closes #38

Runs `make data` prior to testing tiledbsoma-py. New requirement introduced upstream in https://github.com/single-cell-data/TileDB-SOMA/pull/3712

Tests passed in [test run on my fork](https://github.com/jdblischak/centralized-tiledb-nightlies/actions/runs/13548928832)