### PR TITLE
Stop running failing tests for deprecated TileDB-MariaDB

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -559,10 +559,13 @@ jobs:
           # Fail if not properly linked to nightly libtiledb.so
           ldd builddir/storage/mytile/ha_mytile.so | \
             grep -q $(pwd)/install-libtiledb/lib/libtiledb.so
-      - name: Test TileDB-MariaDB
-        run: |
-          cd builddir
-          ./mysql-test/mysql-test-run.pl --suite=mytile
+      # Failing tests are being tracked upstream at
+      # https://github.com/TileDB-Inc/TileDB-MariaDB/issues/393
+      #
+      # - name: Test TileDB-MariaDB
+      #   run: |
+      #     cd builddir
+      #     ./mysql-test/mysql-test-run.pl --suite=mytile
   tiledb-go:
     runs-on: ubuntu-24.04
     needs: [libtiledb]


### PR DESCRIPTION
Closes #50 

* The TileDB-MariaDB tests started failing 3 weeks ago (#50)
* TileDB-MariaDB is deprecated (https://github.com/TileDB-Inc/TileDB-MariaDB/pull/390)
* Fixing the failing tests is non-trivial (https://github.com/TileDB-Inc/TileDB-MariaDB/pull/394#issuecomment-3047040248)
* The failing tests are being tracked upstream (https://github.com/TileDB-Inc/TileDB-MariaDB/issues/393), so continuing to monitor them here is redundant